### PR TITLE
MAYH-4496 add unit and property test for Text

### DIFF
--- a/test/Avro/Codec/TextSpec.hs
+++ b/test/Avro/Codec/TextSpec.hs
@@ -36,6 +36,7 @@ instance FromAvro OnlyText where
 spec :: Spec
 spec = describe "Avro.Codec.TextSpec" $ do
   it "Can decode \"This is an unit test\"" $ do
+    -- The '(' here is the length (ASCII value) of the string
     let expectedBuffer = "(This is an unit test"
     let value = OnlyText "This is an unit test"
     encode value `shouldBe` expectedBuffer

--- a/test/Avro/Codec/TextSpec.hs
+++ b/test/Avro/Codec/TextSpec.hs
@@ -1,11 +1,46 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Avro.Codec.TextSpec (spec) where
 
-import Test.Hspec
-import qualified Test.QuickCheck as Q
+import           Data.Avro
+import           Data.Avro.Schema
+import           Data.Text
+import           Data.Tagged
+import           Test.Hspec
+import qualified Data.Avro.Types      as AT
+import qualified Test.QuickCheck      as Q
 
 {-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
 
+newtype OnlyText = OnlyText
+  {onlyTextValue :: Text
+  } deriving (Show, Eq)
+
+onlyTextSchema :: Schema
+onlyTextSchema =
+  let fld nm = Field nm [] Nothing Nothing
+  in Record "OnlyText" (Just "test.contract") [] Nothing Nothing
+        [ fld "onlyTextValue" String Nothing
+        ]
+
+instance ToAvro OnlyText where
+  toAvro sa = record onlyTextSchema
+    [ "onlyTextValue" .= onlyTextValue sa ]
+  schema = pure onlyTextSchema
+
+instance FromAvro OnlyText where
+  fromAvro (AT.Record _ r) =
+    OnlyText <$> r .: "onlyTextValue"
+
 spec :: Spec
-spec = describe "Avro.Codec.Int64Spec" $ do
-  it "stub" $ do
-    True `shouldBe` True
+spec = describe "Avro.Codec.TextSpec" $ do
+  it "Can decode \"This is an unit test\"" $ do
+    let expectedBuffer = "(This is an unit test"
+    let value = OnlyText "This is an unit test"
+    encode value `shouldBe` expectedBuffer
+
+  it "Can decode encoded Text values" $ do
+    Q.property $ \(t :: String) ->
+      let x = untag (schema :: Tagged OnlyText Type) in
+        decode x (encode (OnlyText (pack t))) == Success (OnlyText (pack t))


### PR DESCRIPTION
## Changes
Added unit and property test for Text

## Testing
stack test shows:

```
Avro.Codec.Text
  Avro.Codec.TextSpec
    Can decode "This is an unit test"
    Can decode encoded Text values
```